### PR TITLE
sparsehash requires SSE4.1 instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: vg libvg.a test/build_graph
 	cd test && $(MAKE)
 
 test/build_graph: test/build_graph.cpp
-	$(CXX) test/build_graph.cpp $(INCLUDES) -lvg $(LDFLAGS) -o test/build_graph
+	$(CXX) $(CXXFLAGS) test/build_graph.cpp $(INCLUDES) -lvg $(LDFLAGS) -o test/build_graph
 
 profiling:
 	$(MAKE) CXXFLAGS="$(CXXFLAGS) -g" all

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean test get-deps
 
-CXX=g++ -std=c++11 -fopenmp -g
-CXXFLAGS=-O3
+CXX=g++ 
+CXXFLAGS=-O3 -std=c++11 -fopenmp -g -march=native
 VCFLIB=vcflib
 LIBVCFLIB=$(VCFLIB)/libvcflib.a
 LIBGSSW=gssw/src/libgssw.a


### PR DESCRIPTION
The following unpleasant error is fixed on machines that do not by default enable SSE4.1 in GCC.

```
In file included from gssw/src/gssw.h:19:0,
                 from gssw_aligner.hpp:7,
                 from gssw_aligner.cpp:1:
/usr/lib64/gcc/x86_64-suse-linux/4.8/include/smmintrin.h:31:3: error: #error "SSE4.1 instruction set not enabled"
 # error "SSE4.1 instruction set not enabled"
   ^
In file included from gssw_aligner.hpp:7:0,
                 from gssw_aligner.cpp:1:
```