### PR TITLE
vg index: ensure failure when given non-existent input filename(s)

### DIFF
--- a/test/t/06_vg_index.t
+++ b/test/t/06_vg_index.t
@@ -7,13 +7,16 @@ PATH=..:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 23
+plan tests 24
 
 vg construct -r small/x.fa -v small/x.vcf.gz >x.vg
 is $? 0 "construction"
 
 vg index -s x.vg
 is $? 0 "indexing nodes and edges of graph"
+
+vg index -s -d x.vg.index x.vg bogus123.vg
+is $? 134 "fail with nonexistent file"
 
 vg index -k 11 x.vg
 is $? 0 "indexing 11mers"

--- a/vg_set.cpp
+++ b/vg_set.cpp
@@ -12,6 +12,7 @@ void VGset::transform(std::function<void(VG*)> lambda) {
             g = new VG(std::cin, show_progress);
         } else {
             ifstream in(name.c_str());
+            if (!in) throw ifstream::failure("failed to open " + name);
             g = new VG(in, show_progress);
             in.close();
         }
@@ -34,6 +35,7 @@ void VGset::for_each(std::function<void(VG*)> lambda) {
             g = new VG(std::cin, show_progress);
         } else {
             ifstream in(name.c_str());
+            if (!in) throw ifstream::failure("failed to open " + name);
             g = new VG(in, show_progress);
             in.close();
         }


### PR DESCRIPTION
otherwise they're silently ignored which is dangerous when taking in a lengthy list of filenames.