### PR TITLE
Make chop cut off consistently-sized pieces like was probably intended

### DIFF
--- a/vg.cpp
+++ b/vg.cpp
@@ -729,10 +729,12 @@ void VG::dice_nodes(int max_node_size) {
                 }
                 int segment_size = node_size/div;
                 int i = 0;
-                while (i < node_size) {
-                    divide_node(n, i, l, r);
+                for(int i = 0; i < div - 1; i++) {
+                    // For each division between the div new pieces, break off a piece of the determined size at the left
+                    divide_node(n, segment_size, l, r);
+                    
+                    // Keep dividing the right node
                     n = r;
-                    i += segment_size;
                 }
             }
         };


### PR DESCRIPTION
Right now it's trying to chop nodes at progressively larger offsets, and can eventually try to chop nodes at offsets greater than their lengths.