### PR TITLE
Several bugfixes

### DIFF
--- a/index.cpp
+++ b/index.cpp
@@ -1477,7 +1477,7 @@ void Index::get_range(int64_t from_id, int64_t to_id, VG& graph) {
             graph.add_edge(edge);
         } break;
         case 'e': {
-            // Key describes an edge on the start of a node
+            // Key describes an edge on the end of a node
             Edge edge;
             int64_t id1, id2;
             char type;
@@ -1543,8 +1543,12 @@ void Index::for_kmer_range(const string& kmer, function<void(string&, string&)> 
 }
 
 void Index::for_graph_range(int64_t from_id, int64_t to_id, function<void(string&, string&)> lambda) {
-    string start = key_for_node(from_id);
-    string end = key_for_node(to_id+1);
+    // We can't rely on edge keys coming after their node keys, so we need to
+    // trim off the trailing "+n" from the first key, so we get all the edges.
+    string start = key_for_node(from_id).substr(0,3+sizeof(int64_t));
+    // Similarly, we need to stop before the edges attached to this other node,
+    // if there are any.
+    string end = key_for_node(to_id+1).substr(0,3+sizeof(int64_t));
     // apply to the range matching the kmer in the db
     for_range(start, end, lambda);
 }

--- a/index.hpp
+++ b/index.hpp
@@ -271,8 +271,11 @@ public:
     void get_kmer_subgraph(const string& kmer, VG& graph);
     uint64_t approx_size_of_kmer_matches(const string& kmer);
     void approx_sizes_of_kmer_matches(const vector<string>& kmers, vector<uint64_t>& sizes);
+    // Run the given function on all the keys and values in the database describing instances of the given kmer.
     void for_kmer_range(const string& kmer, function<void(string&, string&)> lambda);
+    // In the given map by node ID, fill in the vector with the offsets in that node at which the given kmer starts.
     void get_kmer_positions(const string& kmer, map<int64_t, vector<int32_t> >& positions);
+    // In the given map by kmer, fill in the vector with the node IDs and offsets at which the given kmer starts.
     void get_kmer_positions(const string& kmer, map<string, vector<pair<int64_t, int32_t> > >& positions);
     void prune_kmers(int max_kb_on_disk);
 

--- a/main.cpp
+++ b/main.cpp
@@ -3227,6 +3227,12 @@ int main_view(int argc, char** argv) {
         return 1;
     }
 
+    if(!graph->is_valid()) {
+        // If we're converting the graph, we might as well make sure it's valid.
+        // This is especially useful for JSON import.
+        cerr << "[vg view] warning: graph is invalid!" << endl;
+    }
+
     // Now we know graph was filled in from the input format. Spit it out in the
     // requested output format.
 

--- a/vg.cpp
+++ b/vg.cpp
@@ -3022,16 +3022,6 @@ bool VG::is_valid(void) {
         }
     }
 
-    if (head_nodes().empty()) {
-        cerr << "graph invalid: no head nodes" << endl;
-        return false;
-    }
-
-    if (tail_nodes().empty()) {
-        cerr << "graph invalid: no tail nodes" << endl;
-        return false;
-    }
-
     return true;
 }
 

--- a/vg.cpp
+++ b/vg.cpp
@@ -1475,8 +1475,6 @@ Edge* VG::create_edge(Node* from, Node* to, bool from_start, bool to_end) {
 
 Edge* VG::create_edge(int64_t from, int64_t to, bool from_start, bool to_end) {
     //cerr << "creating edge " << from << "->" << to << endl;
-    // prevent self-linking (violates DAG/partial ordering property)
-    if (to == from) return nullptr;
     // ensure the edge (or another between the same sides) does not already exist
     Edge* edge = get_edge(NodeSide(from, !from_start), NodeSide(to, to_end));
     if (edge) {

--- a/vg.cpp
+++ b/vg.cpp
@@ -3316,6 +3316,13 @@ void VG::add_single_start_end_marker(int length, char start_char, Node*& head_ta
         unattached.insert(node);
     });
 
+    // We handle the head and tail joining ourselves so we can do connected components.
+    // We collect these before we add the new head/tail node so we don't have to filter it out later.
+    vector<Node*> heads;
+    head_nodes(heads);
+    vector<Node*> tails;
+    tail_nodes(tails);
+
     if(head_tail_node == nullptr) {
         // We get to create the node. In its forward orientation it's the start node, so we use the start character.
         string start_string(length, start_char);
@@ -3324,12 +3331,6 @@ void VG::add_single_start_end_marker(int length, char start_char, Node*& head_ta
         // We got a node to use
         add_node(*head_tail_node);
     }
-
-    // We handle the head and tail joining ourselves so we can do connected components.
-    vector<Node*> heads;
-    head_nodes(heads);
-    vector<Node*> tails;
-    tail_nodes(tails);
 
     for(Node* head : heads) {
         if(unattached.count(head)) {

--- a/vg.hpp
+++ b/vg.hpp
@@ -63,6 +63,10 @@ public:
     }
 };
 
+inline ostream& operator<<(ostream& out, const NodeTraversal& nodetraversal) {
+    return out << nodetraversal.node->id() << " " << (nodetraversal.backward ? "rev" : "fwd");
+}
+
 // Represents one side of a Node, identified by ID, for the purposes of
 // indexing edges.
 class NodeSide {
@@ -111,6 +115,10 @@ public:
         return minmax(NodeSide(end_id, true), NodeSide(oriented_other.first, oriented_other.second));
     }
 };
+
+inline ostream& operator<<(ostream& out, const NodeSide& nodeside) {
+    return out << nodeside.node << " " << (nodeside.is_end ? "end" : "start");
+}
 
 }
 


### PR DESCRIPTION
Here are several bugfix commits that I didn't want to split out into their own branches.

* In the mapper, `balanced_kmers` wasn't generating the very last kmer if it ended at the end of the input sequence. Now it is.
* `VG::is_valid` no longer requires heads or tails, since some cyclic graphs don't have that.
* `VG::create_edge` can now create self loops.
* Non-reversing self loops are now properly removed when feeding the graph into GSSW.
* Self-loops are now no longer spuriously requested (and, previously, thrown out by `create_edge`) when attaching a node to all heads or tails, or when creating the GCSA2 start/end node.
* `vg view` now validates the graph when doing conversion.
* The code for getting the edges for a graph range from the index has been fixed up to account for the fact that the key for a node no longer sorts before all the keys for its edges. 

