### PR TITLE
Add a -n option to annotate edges with paths that use them in dot output

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3037,6 +3037,7 @@ void help_view(char** argv) {
          << "    -d, --dot            output dot format" << endl
          << "    -p, --show-paths     show paths in dot output" << endl
          << "    -w, --walk-paths     add labeled edges to represent paths in dot output" << endl
+         << "    -n, --annotate-paths add labels to normal edges to represent paths in dot output" << endl
          << "    -s, --random-seed N  use this seed when assigning path symbols in dot output" << endl
          
          << "    -b, --bam            input BAM or other htslib-parseable alignments" << endl
@@ -3072,6 +3073,7 @@ int main_view(int argc, char** argv) {
     bool interleaved_fastq = false;
     bool show_paths_in_dot = false;
     bool walk_paths_in_dot = false;
+    bool annotate_paths_in_dot = false;
     int seed_val = time(NULL);
 
     int c;
@@ -3096,12 +3098,13 @@ int main_view(int argc, char** argv) {
                 {"aln-graph", required_argument, 0, 'A'},
                 {"show-paths", no_argument, 0, 'p'},
                 {"walk-paths", no_argument, 0, 'w'},
+                {"annotate-paths", no_argument, 0, 'n'},
                 {"random-seed", required_argument, 0, 's'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:w",
+        c = getopt_long (argc, argv, "dgFjJhvVpaGbifA:s:wn",
                          long_options, &option_index);
         
         /* Detect the end of the options. */
@@ -3120,6 +3123,10 @@ int main_view(int argc, char** argv) {
 
         case 'w':
             walk_paths_in_dot = true;
+            break;
+            
+        case 'n':
+            annotate_paths_in_dot = true;
             break;
 
         case 's':
@@ -3392,7 +3399,7 @@ int main_view(int argc, char** argv) {
     // requested output format.
 
     if (output_type == "dot") {
-        graph->to_dot(std::cout, alns, show_paths_in_dot, walk_paths_in_dot, seed_val);
+        graph->to_dot(std::cout, alns, show_paths_in_dot, walk_paths_in_dot, annotate_paths_in_dot, seed_val);
     } else if (output_type == "json") {
         cout << pb2json(graph->graph) << endl;
     } else if (output_type == "gfa") {

--- a/vg.cpp
+++ b/vg.cpp
@@ -2984,7 +2984,8 @@ bool VG::is_valid(void) {
     return true;
 }
 
-void VG::to_dot(ostream& out, vector<Alignment> alignments, bool show_paths, bool walk_paths, int random_seed) {
+void VG::to_dot(ostream& out, vector<Alignment> alignments, bool show_paths, bool walk_paths, bool annotate_paths,
+                int random_seed) {
     out << "digraph graphname {" << endl;
     out << "    node [shape=plaintext];" << endl;
     out << "    rankdir=LR;" << endl;
@@ -2997,6 +2998,50 @@ void VG::to_dot(ostream& out, vector<Alignment> alignments, bool show_paths, boo
         auto node_paths = paths.of_node(n->id());
         out << "    " << n->id() << " [label=\"" << n->id() << ":" << n->sequence() << "\",shape=box,penwidth=2];" << endl;
     }
+    
+    
+    // We're going to fill this in with all the path (symbol, color) label
+    // pairs that each edge should get, by edge pointer. If a path takes an
+    // edge multiple times, it will appear only once.
+    map<Edge*, set<pair<string, string>>> symbols_for_edge;
+    
+    if(annotate_paths) {
+        // We're going to annotate the paths, so we need to give them symbols and colors.
+        Pictographs picts(random_seed);
+        Colors colors(random_seed);
+        set<string> used_colors; // cycle through these
+    
+        // Work out what path symbols belong on what edges
+        function<void(Path&)> lambda = [this, &picts, &colors, &symbols_for_edge, &used_colors](Path& path) {
+            // Make up the path's label
+            string path_label = picts.random();
+            if (used_colors.size() == colors.colors.size()) {
+                used_colors.clear();
+            }
+            string color = colors.random();
+            while (used_colors.count(color)) {
+                color = colors.random();
+            }
+            used_colors.insert(color);
+            
+            
+            for (int i = 0; i < path.mapping_size(); ++i) {
+                const Mapping& m1 = path.mapping(i);
+                if (i < path.mapping_size()-1) {
+                    const Mapping& m2 = path.mapping(i+1);
+                    
+                    // Find the Edge connecting the mappings in the order they occur in the path.
+                    Edge* edge_used = get_edge(NodeTraversal(get_node(m1.position().node_id()), m1.is_reverse()),
+                                               NodeTraversal(get_node(m2.position().node_id()), m2.is_reverse()));
+                    
+                    // Say that edge should have this symbol                       
+                    symbols_for_edge[edge_used].insert(make_pair(path_label, color));
+                }
+            }
+        };
+        paths.for_each(lambda);
+    }
+    
     for (int i = 0; i < graph.edge_size(); ++i) {
         Edge* e = graph.mutable_edge(i);
         auto from_paths = paths.of_node(e->from());
@@ -3012,6 +3057,9 @@ void VG::to_dot(ostream& out, vector<Alignment> alignments, bool show_paths, boo
                             || !paths.are_consecutive_nodes_in_path(e->from(), e->to(),
                                                                     *both_paths.begin())));
                                                                     */
+
+        // Grab the annotation symbols for this edge.
+        auto annotations = symbols_for_edge.find(e);
 
         // Is the edge in the "wrong" direction for rank constraints?
         bool is_backward = e->from_start() && e->to_end();
@@ -3046,7 +3094,22 @@ void VG::to_dot(ostream& out, vector<Alignment> alignments, bool show_paths, boo
             out << "arrowhead=normal,";
             out << "headport=nw";
         }
-        out << ",penwidth=2];" << endl;
+        out << ",penwidth=2";
+        
+        if(annotations != symbols_for_edge.end()) {
+            // We need to put a label on the edge with all the colored
+            // characters for paths using it.
+            out << ",label=<";
+            
+            for(auto& string_and_color : (*annotations).second) {
+                // Put every symbol in its font tag.
+                out << "<FONT COLOR=\"" << string_and_color.second << "\">" << string_and_color.first << "</FONT>";
+            }
+            
+            out << ">";
+        }   
+        
+        out << "];" << endl;
 
         if(is_backward) {
             // We don't need this duplicate edge
@@ -3116,6 +3179,7 @@ void VG::to_dot(ostream& out, vector<Alignment> alignments, bool show_paths, boo
         Pictographs picts(random_seed);
         Colors colors(random_seed);
         set<string> used_colors; // cycle through these
+        
         function<void(Path&)> lambda = 
             [this,&pathid,&out,&picts,&colors,&used_colors,show_paths,walk_paths]
             (Path& path) {

--- a/vg.hpp
+++ b/vg.hpp
@@ -515,7 +515,8 @@ public:
     //void node_replace_prev(Node* node, Node* before, Node* after);
     //void node_replace_next(Node* node, Node* before, Node* after);
 
-    void to_dot(ostream& out, vector<Alignment> alignments = {}, bool show_paths = false, bool walk_paths = false, int random_seed = 0);
+    void to_dot(ostream& out, vector<Alignment> alignments = {}, bool show_paths = false, bool walk_paths = false,
+                bool annotate_paths = false, int random_seed = 0);
     void to_gfa(ostream& out);
     bool is_valid(void);
 


### PR DESCRIPTION
Looks good. This is to test it out.