### PR TITLE
Build on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ SYS=$(shell uname -s)
 ifeq (${SYS},Darwin)
 	CXXFLAGS:=$(CXXFLAGS) -msse2 #needed to link against gssw
 	LDFLAGS:=$(LDFLAGS) -L/opt//local/lib/ # needed for macports jansson
+	STATICFLAGS= # -static doesn't work on OSX unless libgcc compiled as static. 
 	ROCKSDB_PORTABLE=PORTABLE=1 # needed to build rocksdb without weird assembler options
 	CLEAN_SNAPPY_AG=sed -i -e "s/[[:<:]]libtoolize[[:>:]]/glibtoolize/g" autogen.sh
 else
 	LDFLAGS:=$(LDFLAGS) -lrt
+	STATICFLAGS=-static -static-libstdc++ -static-libgcc
 	ROCKSDB_PORTABLE=
 	CLEAN_SNAPPY_AG=:
 endif
@@ -138,7 +140,7 @@ entropy.o: entropy.cpp entropy.hpp
 	$(CXX) $(CXXFLAGS) -c -o entropy.o entropy.cpp $(INCLUDES)
 
 vg: $(LIBS) $(LIBVCFLIB) $(fastahack/Fasta.o) $(LIBGSSW) $(LIBROCKSDB) $(LIBSNAPPY) $(LIBHTS) $(LIBPROTOBUF) $(LIBGCSA2) $(SPARSEHASH) $(SDSLLITE) $(LIBXG)
-	$(CXX) $(CXXFLAGS) -o vg $(LIBS) $(INCLUDES) $(LDFLAGS) -static -static-libstdc++ -static-libgcc
+	$(CXX) $(CXXFLAGS) -o vg $(LIBS) $(INCLUDES) $(LDFLAGS)
 
 libvg.a: vg
 	ar rs libvg.a $(LIBS)


### PR DESCRIPTION
This is a minor change to the Makefile to keep allow building on OSX by disabling static link flag on that platform (some details about this here [here](http://stackoverflow.com/questions/3801011/ld-library-not-found-for-lcrt0-o-on-osx-10-6-with-gcc-clang-static-flag)).

PLEASE NOTE: For vg to build on OSX, the xg submodule will also need to be updated to a version that includes [xg pull request 4](https://github.com/ekg/xg/pull/4).    
