### PR TITLE
resolves issue #99

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all clean test get-deps
 
 CXX=g++
-CXXFLAGS=-O3 -std=c++11 -fopenmp -g # -ffast-math -funroll-loops
+CXXFLAGS=-O3 -std=c++11 -fopenmp -g -msse4.1 # -ffast-math -funroll-loops
 VCFLIB=vcflib
 LIBVCFLIB=$(VCFLIB)/libvcflib.a
 LIBGSSW=gssw/src/libgssw.a


### PR DESCRIPTION
The compilation error reported is:

/usr/lib/gcc/x86_64-linux-gnu/4.8/include/smmintrin.h:31:3: error:
 # error "SSE4.1 instruction set not enabled"
   ^

I'm using:

$ g++ --version
g++ (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is
NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
PURPOSE.

$ gcc --version
gcc (Ubuntu 4.9.1-16ubuntu6) 4.9.1
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is
NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR
PURPOSE.

See
http://stackoverflow.com/questions/3754491/sse4-1-intrinsics-compilation-error-on-mac