### PR TITLE
resolves issue #100

### DIFF
--- a/mapper.cpp
+++ b/mapper.cpp
@@ -184,7 +184,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         }
         
         // Sort these alignments by score, descending
-        sort(alignments1.begin(), alignments1.end(), [](Alignment& a, Alignment& b) {
+        sort(alignments1.begin(), alignments1.end(), [](const Alignment& a, const Alignment& b) {
             return a.score() > b.score();
         });
         
@@ -215,7 +215,7 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
         }
         
         // Sort these alignments by score, descending
-        sort(alignments2.begin(), alignments2.end(), [](Alignment& a, Alignment& b) {
+        sort(alignments2.begin(), alignments2.end(), [](const Alignment& a, const Alignment& b) {
             return a.score() > b.score();
         });
         


### PR DESCRIPTION
Was getting the compilation error:

...
mapper.cpp:187:83: note:   no known conversion for argument 1 from ‘const vg::Alignment’ to ‘vg::Alignment&’
...
mapper.cpp:218:83: note:   no known conversion for argument 1 from ‘const vg::Alignment’ to ‘vg::Alignment&’
...

adding 'const' to the latter variables resovled the issue for me.

Here is some of my system information:

$ g++ --version
g++ (Ubuntu 4.8.4-2ubuntu1~14.04) 4.8.4
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ gcc --version
gcc (Ubuntu 4.9.1-16ubuntu6) 4.9.1
Copyright (C) 2014 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.