### PR TITLE
Syntactically correct RDF/JSON for vg (for discussion not for merging at this time)

### DIFF
--- a/test/t/17_vgtordf.t
+++ b/test/t/17_vgtordf.t
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+BASH_TAP_ROOT=../bash-tap
+. ../bash-tap/bash-tap-bootstrap
+
+PATH=..:$PATH # for vg
+
+vgtordf.sh cyclic/all.json | jq .
+  ' 

--- a/test/t/17_vgtordf.t
+++ b/test/t/17_vgtordf.t
@@ -5,5 +5,6 @@ BASH_TAP_ROOT=../bash-tap
 
 PATH=..:$PATH # for vg
 
-vgtordf.sh cyclic/all.json | jq .
-  ' 
+plan tests 1
+vgtordf.sh <(vg view -V  graphs/199754000\:199755000.vg  -j) | jq . 
+is $? 0 "Basic syntax check passes"

--- a/vgtordf.sh
+++ b/vgtordf.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+((
+jq " .path[]|{(\"\(.name)\"):{\"rdf:type\":[{\"value\":\"Path\",\"type\":\"uri\"}]}} " $1|sed '$d';
+jq ".edge[]|{(\"\(.from | tostring)\"):{\"before\":[ {\"value\":(\"\(.to |tostring)\"), \"type\" : \"uri\"}]}}" $1 | sed -e "s_^\}_,_"| sed -e 's_^[\{]__'|sed '1d;$d';
+jq ".node[]|{(\"\(.id | tostring)\"): {\"rdf:value\":[ {\"value\":.sequence, \"type\" : \"literal\"} ] }}" $1|sed -e "s_^\}_,_"| sed -e 's_^[\{]__'|sed '1d;$d';
+echo ',';
+jq  "  .path[].mapping | keys[] as \$k | { (\$k | tostring):{\"node\":[ {\"value\":(.[\$k].position.node_id | tostring) , \"type\":\"uri\"} ], \"step\" : [{\"value\":(\$k | tostring), \"type\":\"literal\"} ]} }" $1 |sed -e "s_^\}_,_"| sed -e 's_^[\{]__';)|sed '$d';echo '}')

--- a/vgtordf.sh
+++ b/vgtordf.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 ((
-jq " .path[]|{(\"\(.name)\"):{\"rdf:type\":[{\"value\":\"Path\",\"type\":\"uri\"}]}} " $1|sed '$d';
+jq " .path[]|{(\"\(.name)\"):{\"http://www.w3.org/1999/02/22-rdf-syntax-ns#type\":[{\"value\":\"Path\",\"type\":\"uri\"}]}} " $1|sed '$d';
 jq ".edge[]|{(\"\(.from | tostring)\"):{\"before\":[ {\"value\":(\"\(.to |tostring)\"), \"type\" : \"uri\"}]}}" $1 | sed -e "s_^\}_,_"| sed -e 's_^[\{]__'|sed '1d;$d';
-jq ".node[]|{(\"\(.id | tostring)\"): {\"rdf:value\":[ {\"value\":.sequence, \"type\" : \"literal\"} ] }}" $1|sed -e "s_^\}_,_"| sed -e 's_^[\{]__'|sed '1d;$d';
+jq ".node[]|{(\"\(.id | tostring)\"): {\"http://www.w3.org/1999/02/22-rdf-syntax-ns#value\":[ {\"value\":.sequence, \"type\" : \"literal\"} ] }}" $1|sed -e "s_^\}_,_"| sed -e 's_^[\{]__'|sed '1d;$d';
 echo ',';
-jq  "  .path[].mapping | keys[] as \$k | { (\$k | tostring):{\"node\":[ {\"value\":(.[\$k].position.node_id | tostring) , \"type\":\"uri\"} ], \"step\" : [{\"value\":(\$k | tostring), \"type\":\"literal\"} ]} }" $1 |sed -e "s_^\}_,_"| sed -e 's_^[\{]__';)|sed '$d';echo '}')
+jq  "  .path[] as \$p|\$p.mapping 
+| keys[] as \$k 
+| { (\$k | tostring):{\"node\":[ {\"value\":(.[\$k].position.node_id | tostring) 
+, \"type\":\"uri\"} ]
+, \"step\" : 
+	[{\"value\":(\$k | tostring)
+	, \"type\":\"literal\"}]
+,\"path\":
+	[{\"value\":(\$p.name),
+	\"type\":\"uri\" } ]}} 
+" $1 |sed -e "s_^\}_,_"| sed -e 's_^[\{]__';)|sed '$d';echo '}')


### PR DESCRIPTION
This pull request is not ready for accepting, but I open it as a starting point for further discussion.

The aim is to have the Variation Graph in an RDF serialisation so that SPARQL/Triplestore databases can load the variation graph and SPARQL queries can be executed on it.

The shell script uses a multitude of jq and sed scripts to translate the JSON output into RDF/JSON as used by the apache jena project. This [RDF/JSON](http://jena.apache.org/documentation/io/rdf-json.html) can then be translated or loaded directly into any SPARQL/RDF store.

Including the rather slow, but useful for testing, jena commandline sparql tool.
e.g. translate the vg json to n-triples and then use SPARQL to rebuild the linear dna sequence for a path.
```
vgtordf.sh x.json | riot --syntax="RDF/JSON" --output="N-Triples" > x.nt
sparql --data x.nt 
"PREFIX :<http://base/> PREFIX rdf:<ttp://www.w3.org/1999/02/22-rdf-syntax-ns#> 
 SELECT ?path (group_concat(?sequence; separator='') as ?pathSeq)
 WHERE {?step :path ?path; 
              :node ?node ;
              :step ?order.
        ?node rdf:value ?sequence} 
 GROUP BY ?path 
 ORDER BY ?order"
```
On the same data one can do for example to give the average "node" sequence length.
```
PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#>SELECT (avg(?len) as ?avglen) WHERE  { ?x  rdf:value ?s . BIND (strlen(?s) as ?len)}
```

The RDF is syntactically correct, but is only useable as a demo that the technology "works". i.e. wrong URI's are generated etc...

RDF/JSON is not a standardised format, JSON-LD would normally be the preferred solution for having a Semantic Web view on existing JSON. As far as I understand JSON-LD can not be used here as "IDs" are implicit indexes in JSON arrays.

Otherwise this small script touches upon some of the questions raised in https://github.com/ga4gh/schemas/issues/287, i.e. should there be a focus on data instead of on API's.
Especially taking into account that while we can have a SPARQL interface data does not need to be stored in a RDF database. For now it means that this data can be stored into content addressable RDF stores such as dydra.