### PR TITLE
Add a Dockerfile for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.git
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:15.04
+
+MAINTAINER Erik Garrison <erik.garrison@gmail.com>
+
+# Make sure the en_US.UTF-8 locale exists, since we need it for tests
+RUN locale-gen en_US en_US.UTF-8 && dpkg-reconfigure locales
+
+# Set up for make get-deps
+RUN mkdir /app
+WORKDIR /app
+COPY Makefile /app/Makefile
+
+# Install vg dependencies and clear the package index
+RUN \
+    apt-get update && \
+    apt-get install -y \
+        build-essential \
+        sudo && \
+    make get-deps && \
+    rm -rf /var/lib/apt/lists/*
+    
+# Move in all the other files
+COPY . /app
+    
+# Build vg
+RUN make -j8
+
+# Make tests. We can't do it in parallel since it cleans up the test binary
+RUN make test
+
+ENTRYPOINT ["/app/vg"]
+

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 all: vg libvg.a
 
 get-deps:
-	sudo apt-get install -qq -y protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev libncurses5-dev automake libtool jq samtools
+	sudo apt-get install -qq -y protobuf-compiler libprotoc-dev libjansson-dev libbz2-dev libncurses5-dev automake libtool jq samtools curl unzip cmake pkg-config wget bc
 
 test: vg libvg.a test/build_graph
 	cd test && $(MAKE)


### PR DESCRIPTION
Also updating the Makefile to cover the dependencies that
aren't in said Docker by default.

Should let you do Docker automated builds (even though that ends up way bigger than just the static binary).