### PR TITLE
Several Bugfixes

### DIFF
--- a/alignment.cpp
+++ b/alignment.cpp
@@ -167,7 +167,7 @@ size_t fastq_unpaired_for_each_parallel(string& filename, function<void(Alignmen
         }
     }
     for (auto& buf : bufs) {
-        delete buf;
+        delete[] buf;
     }
     gzclose(fp);
     return nLines;

--- a/alignment.cpp
+++ b/alignment.cpp
@@ -156,12 +156,15 @@ size_t fastq_unpaired_for_each_parallel(string& filename, function<void(Alignmen
         while (more_data) {
             Alignment aln;
             char* buf = bufs[tid];
+            bool got_anything = false;
 #pragma omp critical (fastq_input)
-            if (more_data) {
-                more_data = get_next_alignment_from_fastq(fp, buf, len, aln);
-                nLines++;
+            {
+                if (more_data) {
+                    got_anything = more_data = get_next_alignment_from_fastq(fp, buf, len, aln);
+                    nLines++;
+                }
             }
-            if (more_data) {
+            if (got_anything) {
                 lambda(aln);
             }
         }
@@ -190,12 +193,15 @@ size_t fastq_paired_interleaved_for_each_parallel(string& filename, function<voi
         while (more_data) {
             Alignment mate1, mate2;
             char* buf = bufs[tid];
+            bool got_anything = false;
 #pragma omp critical (fastq_input)
-            if (more_data) {
-                more_data = get_next_interleaved_alignment_pair_from_fastq(fp, buf, len, mate1, mate2);
-                nLines++;
+            {
+                if (more_data) {
+                    got_anything = more_data = get_next_interleaved_alignment_pair_from_fastq(fp, buf, len, mate1, mate2);
+                    nLines++;
+                }
             }
-            if (more_data) {
+            if (got_anything) {
                 lambda(mate1, mate2);
             }
         }
@@ -225,12 +231,15 @@ size_t fastq_paired_two_files_for_each_parallel(string& file1, string& file2, fu
         while (more_data) {
             Alignment mate1, mate2;
             char* buf = bufs[tid];
+            bool got_anything = false;
 #pragma omp critical (fastq_input)
-            if (more_data) {
-                more_data = get_next_alignment_pair_from_fastqs(fp1, fp2, buf, len, mate1, mate2);
-                nLines++;
+            {
+                if (more_data) {
+                    got_anything = more_data = get_next_alignment_pair_from_fastqs(fp1, fp2, buf, len, mate1, mate2);
+                    nLines++;
+                }
             }
-            if (more_data) {
+            if (got_anything) {
                 lambda(mate1, mate2);
             }
         }

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -923,20 +923,42 @@ vector<Alignment> Mapper::align_threaded(Alignment& alignment, int& kmer_count, 
                 // using 10x the thread_extension
                 int64_t f = max((int64_t)0, idf - (int64_t) max(thread_ex, 1) * 10);
                 int64_t l = idl + (int64_t) max(thread_ex, 1) * 10;
-                if (debug) cerr << "getting node range " << f << "-" << l << endl;
-
-                { // always rebuild the graph
-                    delete graph;
-                    graph = new VG;
+                
+                // We're going to get three ranges. They need to be non-
+                // overlapping since the xg range operation can't handle
+                // repeated nodes.
+                // The ranges are:
+                // The original first-last range
+                // The new range suggested by soft clip handling on the left (f to min(idf, first - 1))
+                // The new range suggested by soft clip handling on the right (max(idl, last + 1) to l)
+                // This way, if soft clip sends us off across an ID discontinuity, we don't try to get like half the graph.
+                
+                // The last two entries might be empty or backward, but the
+                // range functions can just not get anything in those cases.
+                
+                if (debug) {
+                    cerr << "getting node ranges: " << endl;
+                    cerr << "\t" << first << "-" << last << endl;
+                    cerr << "\t" << f << "-" << min(idf, first - 1) << endl;
+                    cerr << "\t" << max(idl, last + 1) << "-" << l << endl;
                 }
+
+                // always rebuild the graph, since we messed it up by sorting it
+                delete graph;
+                graph = new VG;
+                
                 
                 // Get the bigger range, but still go out to context depth afterwards.
                 if(xindex) {
-                    xindex->get_id_range(f, l, graph->graph);
+                    xindex->get_id_range(first, last, graph->graph);
+                    xindex->get_id_range(f, min(idf, first - 1), graph->graph);
+                    xindex->get_id_range(max(idl, last + 1), l, graph->graph);
                     xindex->expand_context(graph->graph, context_depth);
                     graph->rebuild_indexes();
                 } else if(index) {
-                    index->get_range(f, l, *graph);
+                    index->get_range(first, last, *graph);
+                    index->get_range(f, min(idf, first - 1), *graph);
+                    index->get_range(max(idl, last + 1), l, *graph);
                     index->expand_context(*graph, context_depth);
                 } else {
                     cerr << "error:[vg::Mapper] cannot align mate with no graph data" << endl;

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -190,8 +190,8 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
             return a.score() > b.score();
         });
         
-        // Set the secondary bits
-        for(size_t i = 0; i < alignments1.size(); i++) {
+        // Set the secondary bits on all but the first rescued alignment
+        for(size_t i = 1; i < alignments1.size(); i++) {
             alignments1[i].set_is_secondary(true);
         }
     } else if(alignments2.empty() && !alignments1.empty()) {
@@ -221,8 +221,8 @@ pair<vector<Alignment>, vector<Alignment>> Mapper::align_paired_multi(
             return a.score() > b.score();
         });
         
-        // Set the secondary bits
-        for(size_t i = 0; i < alignments2.size(); i++) {
+        // Set the secondary bits on all but the first rescued alignment
+        for(size_t i = 1; i < alignments2.size(); i++) {
             alignments2[i].set_is_secondary(true);
         }
     } 


### PR DESCRIPTION
I could split these into separate PRs if that would be useful.

Here are some bugfixes I have made to make VG work for the graph bake-off.

First, I had to change the way that softclips are handled. Previously, soft-clipping would just extend the ID range around a thread a bit past the highest and lowest ID actually used. However, with the context option allowing you to walk along edges out from your thread and pull in nodes with arbitrary IDs, this sometimes lead to very large graphs being pulled out for local alignment, because a range 1000-1010 might pull in e.g. 5 via an edge, have the read align to 5, and then try and fetch range 1-1010 for softclips.

Instead, I changed softclip handling to pull additional nodes in distinct ranges, which may not be contiguous. It's now a more complex heuristic, but it can't produce huge graphs.

The other major bug fix here is in the mate pair rescue code. Previously, I was marking all alignments rescued by the alignment of the mate as secondary. I have changed it to mark all but the highest-scoring as secondary, as it should.

I've also included a couple of minor fixes: using `delete[]` instead of `delete` on an array allocated with `new`, and keeping a per-thread flag for whether a FASTQ read attempt succeeded in the parallel FASTQ parser (which I think helped with some intermittent test failures I was seeing, where the aligner would sometimes drop reads).