### PR TITLE
Added a list of basic packages needed to build vg to the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This model is similar to a number of sequence graphs that have been used in asse
 
 ### building
 
+Before you begin, you'll need to install some basic tools if they are not already installed.
+
+    sudo apt-get install git cmake pkg-config libncurses-dev libbz2-dev
+
 You'll need the protobuf and jansson development libraries installed on your server.
 
     sudo apt-get install protobuf-compiler libprotoc-dev libjansson-dev automake libtool


### PR DESCRIPTION
I tried to install `vg` in a container which was essentially empty and ran into trouble because the packages I list were missing.  I noticed that there were two issues reported where users were missing cmake and pkg-config so I updated the README to list the packages I needed other than a compiler.