### PR TITLE
const-ify references to lambdas

### DIFF
--- a/path.cpp
+++ b/path.cpp
@@ -49,7 +49,7 @@ void Paths::to_graph(Graph& g) {
     }
 }
 
-void Paths::for_each(function<void(Path&)>& lambda) {
+void Paths::for_each(const function<void(Path&)>& lambda) {
     for (auto& p : _paths) {
         const string& name = p.first;
         list<Mapping>& mappings = p.second;
@@ -72,7 +72,7 @@ void Paths::for_each_mapping(const function<void(Mapping*)>& lambda) {
     }
 }
 
-void Paths::for_each_stream(istream& in, function<void(Path&)>& lambda) {
+void Paths::for_each_stream(istream& in, const function<void(Path&)>& lambda) {
     uint64_t count = 0;
     function<void(uint64_t)> handle_count = [this, &count](uint64_t c) { count = c; };
     stream::for_each(in, lambda, handle_count);

--- a/path.hpp
+++ b/path.hpp
@@ -108,8 +108,8 @@ public:
     void append(Graph& g);
     void extend(Paths& p);
     void extend(const Path& p);
-    void for_each(function<void(Path&)>& lambda);
-    void for_each_stream(istream& in, function<void(Path&)>& lambda);
+    void for_each(const function<void(Path&)>& lambda);
+    void for_each_stream(istream& in, const function<void(Path&)>& lambda);
     void increment_node_ids(int64_t inc);
     // Replace the node IDs used as keys with those used as values.
     // This is only efficient to do in a batch.

--- a/pileup.cpp
+++ b/pileup.cpp
@@ -49,7 +49,7 @@ void Pileups::write(ostream& out, uint64_t buffer_size) {
     }
 }
 
-void Pileups::for_each(function<void(NodePileup&)>& lambda) {
+void Pileups::for_each(const function<void(NodePileup&)>& lambda) {
     for (auto& p : _pileups) {
         lambda(*p.second);
     }

--- a/pileup.hpp
+++ b/pileup.hpp
@@ -73,7 +73,7 @@ public:
     void write(ostream& out, uint64_t buffer_size = 1000);
 
     // apply function to each pileup in table
-    void for_each(function<void(NodePileup&)>& lambda);
+    void for_each(const function<void(NodePileup&)>& lambda);
 
     // search hash table for node id
     NodePileup* get(int64_t node_id) {

--- a/stream.hpp
+++ b/stream.hpp
@@ -22,7 +22,7 @@ namespace stream {
 // count is written before the objects, but if it is 0, it is not written
 // if not all objects are written, return false, otherwise true
 template <typename T>
-bool write(std::ostream& out, uint64_t count, std::function<T(uint64_t)>& lambda) {
+bool write(std::ostream& out, uint64_t count, const std::function<T(uint64_t)>& lambda) {
 
     ::google::protobuf::io::ZeroCopyOutputStream *raw_out =
           new ::google::protobuf::io::OstreamOutputStream(&out);
@@ -70,8 +70,8 @@ bool write_buffered(std::ostream& out, std::vector<T>& buffer, uint64_t buffer_l
 
 template <typename T>
 void for_each(std::istream& in,
-              std::function<void(T&)>& lambda,
-              std::function<void(uint64_t)>& handle_count) {
+              const std::function<void(T&)>& lambda,
+              const std::function<void(uint64_t)>& handle_count) {
 
     ::google::protobuf::io::ZeroCopyInputStream *raw_in =
           new ::google::protobuf::io::IstreamInputStream(&in);
@@ -110,15 +110,15 @@ void for_each(std::istream& in,
 
 template <typename T>
 void for_each(std::istream& in,
-              std::function<void(T&)>& lambda) {
+              const std::function<void(T&)>& lambda) {
     std::function<void(uint64_t)> noop = [](uint64_t) { };
     for_each(in, lambda, noop);
 }
 
 template <typename T>
 void for_each_parallel(std::istream& in,
-                       std::function<void(T&)>& lambda,
-                       std::function<void(uint64_t)>& handle_count) {
+                       const std::function<void(T&)>& lambda,
+                       const std::function<void(uint64_t)>& handle_count) {
 
     ::google::protobuf::io::ZeroCopyInputStream *raw_in =
           new ::google::protobuf::io::IstreamInputStream(&in);
@@ -194,7 +194,7 @@ void for_each_parallel(std::istream& in,
 
 template <typename T>
 void for_each_parallel(std::istream& in,
-              std::function<void(T&)>& lambda) {
+              const std::function<void(T&)>& lambda) {
     std::function<void(uint64_t)> noop = [](uint64_t) { };
     for_each_parallel(in, lambda, noop);
 }

--- a/vg_set.cpp
+++ b/vg_set.cpp
@@ -167,8 +167,9 @@ void VGset::index_kmers(Index& index, int kmer_size, int edge_max, int stride, b
 
 }
 
-void VGset::for_each_kmer_parallel(function<void(string&, list<NodeTraversal>::iterator, int, list<NodeTraversal>&, VG&)>& lambda,
-                                   int kmer_size, int edge_max, int stride, bool allow_dups, bool allow_negatives) {
+void VGset::for_each_kmer_parallel(
+    const function<void(string&, list<NodeTraversal>::iterator, int, list<NodeTraversal>&, VG&)>& lambda,
+    int kmer_size, int edge_max, int stride, bool allow_dups, bool allow_negatives) {
     for_each([&lambda, kmer_size, edge_max, stride, allow_dups, allow_negatives, this](VG* g) {
         g->show_progress = show_progress;
         g->progress_message = "processing kmers of " + g->name;

--- a/vg_set.hpp
+++ b/vg_set.hpp
@@ -44,9 +44,10 @@ public:
     // stores kmers of size kmer_size with stride over paths in graphs in the index
     void index_kmers(Index& index, int kmer_size, int edge_max, int stride = 1, 
                      bool allow_negatives = false);
-    void for_each_kmer_parallel(function<void(string&, list<NodeTraversal>::iterator, int, list<NodeTraversal>&, VG&)>& lambda,
-                                int kmer_size, int edge_max, int stride, 
-                                bool allow_dups, bool allow_negatives = false);
+    void for_each_kmer_parallel(
+        const function<void(string&, list<NodeTraversal>::iterator, int, list<NodeTraversal>&, VG&)>& lambda,
+        int kmer_size, int edge_max, int stride, 
+        bool allow_dups, bool allow_negatives = false);
     
     // Write out kmer lines to GCSA2
     void write_gcsa_out(ostream& out, int kmer_size, int edge_max, int stride,


### PR DESCRIPTION
This lets you pass an inline lambda, because the function no
longer requires the ability to assign to the lambda you are
passing in.

I didn't touch the lambdas in stream.hpp; they should be changed
too, both here and in the stream repo.