### PR TITLE
Expose flatAlternates parsing option in vg construct

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4650,7 +4650,8 @@ void help_construct(char** argv) {
          << "    -m, --node-max N      limit the maximum allowable node sequence size" << endl
          << "                          nodes greater than this threshold will be divided" << endl
          << "    -p, --progress        show progress" << endl
-         << "    -t, --threads N       use N threads to construct graph (defaults to numCPUs)" << endl;
+         << "    -t, --threads N       use N threads to construct graph (defaults to numCPUs)" << endl
+         << "    -f, --flat-alts N     don't chop up alternate alleles from input vcf" << endl;
 }
 
 int main_construct(int argc, char** argv) {
@@ -4668,6 +4669,7 @@ int main_construct(int argc, char** argv) {
     int vars_per_region = 25000;
     int max_node_size = 0;
     string ref_paths_file;
+    bool flat_alts = false;
 
     int c;
     while (true) {
@@ -4683,12 +4685,13 @@ int main_construct(int argc, char** argv) {
                 {"threads", required_argument, 0, 't'},
                 {"region", required_argument, 0, 'R'},
                 {"region-is-chrom", no_argument, 0, 'C'},
-                {"node-max", required_argument, 0, 'm'},
+                {"node-max", required_argument, 0, 'm'},\
+                {"flat-alts", no_argument, 0, 'f'},
                 {0, 0, 0, 0}
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "v:r:phz:t:R:m:P:s:C",
+        c = getopt_long (argc, argv, "v:r:phz:t:R:m:P:s:Cf",
                          long_options, &option_index);
         
         /* Detect the end of the options. */
@@ -4732,7 +4735,11 @@ int main_construct(int argc, char** argv) {
         case 'm':
             max_node_size = atoi(optarg);
             break;
-            
+
+        case 'f':
+            flat_alts = true;
+            break;
+                        
         case 'h':
         case '?':
             /* getopt_long already printed an error message. */
@@ -4764,7 +4771,7 @@ int main_construct(int argc, char** argv) {
     // store our reference sequence paths
     Paths ref_paths;
 
-    VG graph(variant_file, reference, region, region_is_chrom, vars_per_region, max_node_size, progress);
+    VG graph(variant_file, reference, region, region_is_chrom, vars_per_region, max_node_size, flat_alts, progress);
 
     if (!ref_paths_file.empty()) {
         ofstream paths_out(ref_paths_file);

--- a/vg.cpp
+++ b/vg.cpp
@@ -1319,14 +1319,14 @@ void VG::vcf_records_to_alleles(vector<vcflib::Variant>& records,
                                 map<long, set<vcflib::VariantAllele> >& altp,
                                 int start_pos,
                                 int stop_pos,
-                                int max_node_size) {
+                                int max_node_size,
+                                bool flat_input_vcf) {
 
     create_progress("parsing variants", records.size());
 
     for (int i = 0; i < records.size(); ++i) {
         vcflib::Variant& var = records.at(i);
         // decompose to alts
-        bool flat_input_vcf = false; // hack
         map<string, vector<vcflib::VariantAllele> > alternates
             = (flat_input_vcf ? var.flatAlternates() : var.parsedAlternates());
         for (auto& alleles : alternates) {
@@ -1810,6 +1810,7 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
        bool target_is_chrom,
        int vars_per_region,
        int max_node_size,
+       bool flat_input_vcf,
        bool showprog) {
 
     init();
@@ -1904,7 +1905,7 @@ VG::VG(vcflib::VariantCallFile& variantCallFile,
 
         map<long,set<vcflib::VariantAllele> > alleles;
         // decompose records int alleles with offsets against our target sequence
-        vcf_records_to_alleles(records, alleles, start_pos, stop_pos, max_node_size);
+        vcf_records_to_alleles(records, alleles, start_pos, stop_pos, max_node_size, flat_input_vcf);
         records.clear(); // clean up
 
         // enforce a maximum node size

--- a/vg.hpp
+++ b/vg.hpp
@@ -259,6 +259,7 @@ public:
        bool target_is_chrom,
        int vars_per_region,
        int max_node_size = 0,
+       bool flat_input_vcf = false,
        bool showprog = false);
     void from_alleles(const map<long, set<vcflib::VariantAllele> >& altp,
                       string& seq,
@@ -267,7 +268,8 @@ public:
                                 map<long, set<vcflib::VariantAllele> >& altp,
                                 int start_pos,
                                 int stop_pos,
-                                int max_node_size = 0);
+                                int max_node_size = 0,
+                                bool flat_input_vcf = false);
     void slice_alleles(map<long, set<vcflib::VariantAllele> >& altp,
                        int start_pos,
                        int stop_pos,


### PR DESCRIPTION
This allows multi-base snps to not get parsed into bases by vcflib, which could be useful for merging linked snps down the road.  