### PR TITLE
Improve vg call parameters' default values

### DIFF
--- a/caller.cpp
+++ b/caller.cpp
@@ -12,12 +12,12 @@ const double Caller::Log_zero = (double)-1e100;
 
 // these values pretty arbitrary at this point
 const double Caller::Default_het_prior = 0.001; // from MAQ
-const int Caller::Default_min_depth = 50;
-const int Caller::Default_max_depth = 500;
-const int Caller::Default_min_support = 25;
-const double Caller::Default_min_frac = 0.85;
+const int Caller::Default_min_depth = 20;
+const int Caller::Default_max_depth = 5000;
+const int Caller::Default_min_support = 20;
+const double Caller::Default_min_frac = 0.75;
 const double Caller::Default_min_likelihood = 1e-50;
-const char Caller::Default_default_quality = 10;
+const char Caller::Default_default_quality = 30;
 
 Caller::Caller(VG* graph,
                double het_prior,

--- a/main.cpp
+++ b/main.cpp
@@ -257,14 +257,16 @@ void help_call(char** argv) {
          << "Compute SNPs from pilup data (prototype! for evaluation only). " << endl
          << endl
          << "options:" << endl
-         << "    -d, --min_depth      minimum depth of pileup (default=" << Caller::Default_min_depth <<")" << endl
-         << "    -e, --max_depth      maximum depth of pileup (default=" << Caller::Default_max_depth <<")" << endl
-         << "    -s, --min_support    minimum number of reads required to support snp (default=" << Caller::Default_min_support <<")" << endl
-         << "    -r, --het_prior      prior for heterozygous genotype (default=" << Caller::Default_het_prior <<")" << endl
-         << "    -l, --leave_uncalled leave un-called graph regions in output" << endl
-         << "    -j, --json           output in JSON" << endl
-         << "    -p, --progress       show progress" << endl
-         << "    -t, --threads N      number of threads to use" << endl;
+         << "    -d, --min_depth         minimum depth of pileup (default=" << Caller::Default_min_depth <<")" << endl
+         << "    -e, --max_depth         maximum depth of pileup (default=" << Caller::Default_max_depth <<")" << endl
+         << "    -s, --min_support       minimum number of reads required to support snp (default=" << Caller::Default_min_support <<")" << endl
+         << "    -r, --het_prior         prior for heterozygous genotype (default=" << Caller::Default_het_prior <<")" << endl
+         << "    -q, --default_read_qual phred quality score to use if none found in the pileup (default="
+         << (int)Caller::Default_default_quality << ")" << endl
+         << "    -l, --leave_uncalled    leave un-called graph regions in output" << endl
+         << "    -j, --json              output in JSON" << endl
+         << "    -p, --progress          show progress" << endl
+         << "    -t, --threads N         number of threads to use" << endl;
 }
 
 int main_call(int argc, char** argv) {
@@ -278,6 +280,7 @@ int main_call(int argc, char** argv) {
     int min_depth = Caller::Default_min_depth;
     int max_depth = Caller::Default_max_depth;
     int min_support = Caller::Default_min_support;
+    int default_read_qual = Caller::Default_default_quality;
     bool leave_uncalled = false;
     bool output_json = false;
     bool show_progress = false;
@@ -291,6 +294,7 @@ int main_call(int argc, char** argv) {
                 {"min_depth", required_argument, 0, 'd'},
                 {"max_depth", required_argument, 0, 'e'},
                 {"min_support", required_argument, 0, 's'},
+                {"default_read_qual", required_argument, 0, 'q'},
                 {"leave_uncalled", no_argument, 0, 'l'},
                 {"json", no_argument, 0, 'j'},
                 {"progress", no_argument, 0, 'p'},
@@ -300,7 +304,7 @@ int main_call(int argc, char** argv) {
             };
 
         int option_index = 0;
-        c = getopt_long (argc, argv, "d:e:s:ljpr:t:",
+        c = getopt_long (argc, argv, "d:e:s:q:ljpr:t:",
                          long_options, &option_index);
 
         /* Detect the end of the options. */
@@ -317,6 +321,9 @@ int main_call(int argc, char** argv) {
             break;
         case 's':
             min_support = atoi(optarg);
+            break;
+        case 'q':
+            default_read_qual = atoi(optarg);
             break;
         case 'l':
             leave_uncalled = true;
@@ -399,7 +406,7 @@ int main_call(int argc, char** argv) {
     Caller caller(graph,
                   het_prior, min_depth, max_depth, min_support,
                   Caller::Default_min_frac, Caller::Default_min_likelihood,
-                  leave_uncalled);
+                  leave_uncalled, default_read_qual);
 
     function<void(NodePileup&)> lambda = [&caller](NodePileup& pileup) {
         caller.call_node_pileup(pileup);

--- a/test/t/18_vg_call.t
+++ b/test/t/18_vg_call.t
@@ -11,10 +11,10 @@ plan tests 2
 # Toy example of hand-made pileup (and hand inspected truth) to make sure some
 # obvious (and only obvious) SNPs are detected by vg call
 vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa > tiny.vg
-vg view -J -l call/pileup.json -L | vg call tiny.vg - -j -s 10 -d 10 > calls.json
+vg view -J -l call/pileup.json -L | vg call tiny.vg - -j -s 10 -d 10 -q 10 > calls.json
 is $(jq --argfile a calls.json --argfile b call/truth.json -n '($a | (.. | arrays) |= sort) as $a | ($b | (.. | arrays) |= sort) as $b | $a == $b') true "vg call produces the expected output for toy snp test case."
 
-vg view -J -l call/pileup.json -L | vg call tiny.vg - -j -s 10 -d 10 -l > calls_l.json
+vg view -J -l call/pileup.json -L | vg call tiny.vg - -j -s 10 -d 10 -q 10 -l > calls_l.json
 is $(jq --argfile a calls_l.json --argfile b call/truth_l.json -n '($a | (.. | arrays) |= sort) as $a | ($b | (.. | arrays) |= sort) as $b | $a == $b') true "vg call -l produces the expected output for toy snp test case."
 
 rm -f calls_l.json calls.json tiny.vg


### PR DESCRIPTION
These new values should be less likely to not call stuff, especially in the absence of read quality scores. 

This should resolve issue #145. 

* expose default phred score parameter on command line 
* increase the default phred score from 10 to 30
* increase the default max depth from 500 to 5000
* decrease min depth from 50 to 20
* decrease min support from 25 to 20
* decrease min snp fraction from .85 to .75
