### PR TITLE
Reverse paths

### DIFF
--- a/test/reversing/reversing_path.json
+++ b/test/reversing/reversing_path.json
@@ -1,0 +1,35 @@
+{
+    "node": [
+        {"id": 24, "sequence": "GATTACA"},
+        {"id": 25, "sequence": "CATTAG"}
+    ],
+    "edge": [
+        {
+            "from": 24,
+            "to": 25
+        }
+    ],
+    "path": [
+        {
+            "name": "GI262359905",
+            "mapping": [
+                {
+                    "rank": 1,
+                    "position": {
+                        "node_id": 25,
+                        "offset": 5
+                    },
+                    "is_reverse": true
+                },
+                {
+                    "rank": 2,
+                    "position": {
+                        "node_id": 24,
+                        "offset": 6
+                    },
+                    "is_reverse": true
+                }
+            ]
+        }
+    ]
+}

--- a/test/t/14_vg_mod.t
+++ b/test/t/14_vg_mod.t
@@ -7,7 +7,7 @@ PATH=..:$PATH # for vg
 
 export LC_ALL="en_US.utf8" # force ekg's favorite sort order 
 
-plan tests 17
+plan tests 18
 
 is $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep ^P | wc -l) \
     $(vg construct -r small/x.fa -v small/x.vcf.gz | vg mod -k x - | vg view - | grep ^S | wc -l) \
@@ -51,6 +51,8 @@ is $(vg view -v graphs/normalize_me.gfa | vg mod -n - | vg view - | md5sum | cut
 is $(vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg mod -N - | vg view - | grep ^P |wc -l) \
    $(vg construct -v tiny/tiny.vcf.gz -r tiny/tiny.fa | vg mod -N - | vg view - | grep ^S |wc -l) \
    "vg mod removes non-path nodes and edge"
+
+is "$(vg view -Jv reversing/reversing_path.json | vg mod -X 3 - | vg validate - && echo 'Graph is valid')" "Graph is valid" "chopping a graph works correctly with reverse mappings"
 
 is $(vg view -Jv msgas/inv-mess.json | vg mod -u - | md5sum | cut -f 1 -d\ ) 9684fb6d14ffe5cb8e21cc11abbf04d0 "unchop correctly handles a graph with an inversion"
 

--- a/utility.hpp
+++ b/utility.hpp
@@ -30,7 +30,7 @@ bool allATGC(string& s);
 void mapping_cigar(const Mapping& mapping, vector<pair<int, char> >& cigar);
 string cigar_string(vector<pair<int, char> >& cigar);
 string mapping_string(const string& source, const Mapping& mapping);
-void divide_invariant_mapping(Mapping& orig, Mapping& left, Mapping& right, int offset, Node* nl, Node* nr);
+void divide_invariant_mapping(Mapping& orig, Mapping& left, Mapping& right, int offset, Node* n, Node* nl, Node* nr);
 
 }
 

--- a/vg.cpp
+++ b/vg.cpp
@@ -1385,6 +1385,9 @@ void VG::vcf_records_to_alleles(vector<vcflib::Variant>& records,
 }
 
 void VG::dice_nodes(int max_node_size) {
+    // We're going to chop up everything, so clear out the path ranks.
+    paths.clear_node_ranks();
+
     if (max_node_size) {
         vector<Node*> nodes; nodes.reserve(size());
         for_each_node(
@@ -1418,6 +1421,9 @@ void VG::dice_nodes(int max_node_size) {
             lambda(nodes[i]);
         }
     }
+    
+    // Set the ranks again
+    paths.rebuild_mapping_aux();
 }
 
 /*
@@ -2752,6 +2758,7 @@ void VG::keep_path(string& path_name) {
     keep_paths(s, k);
 }
 
+
 // utilities
 void VG::divide_node(Node* node, int pos, Node*& left, Node*& right) {
 
@@ -2820,6 +2827,12 @@ void VG::divide_node(Node* node, int pos, Node*& left, Node*& right) {
         }
         for (auto m : to_divide) {
             // we have to divide the mapping
+            
+#ifdef debug
+#pragma omp critical (cerr)
+            cerr << omp_get_thread_num() << ": dividing mapping " << pb2json(*m) << endl;
+#endif
+            
             string path_name = paths.mapping_path_name(m);
             Mapping l, r; divide_invariant_mapping(*m, l, r, pos, left, right);
             // with the mapping divided, insert the pieces where the old one was
@@ -2827,6 +2840,12 @@ void VG::divide_node(Node* node, int pos, Node*& left, Node*& right) {
             // insert right then left (insert puts *before* the iterator)
             mpit = paths.insert_mapping(mpit, path_name, r);
             mpit = paths.insert_mapping(mpit, path_name, l);
+
+#ifdef debug
+#pragma omp critical (cerr)
+            cerr << omp_get_thread_num() << ": produced mappings " << pb2json(l) << " and " << pb2json(r) << endl;
+#endif
+            
         }
     }
 
@@ -3241,6 +3260,7 @@ void VG::expand_path(list<NodeTraversal>& path, vector<list<NodeTraversal>::iter
 // Mappings are provided as a tuple of <offset, mapping, start/end indicator>, where the
 // start/end indicator lets us know if the mapping may contain a soft clip from the start (-1) or
 // end (1) of a path. (0) indicates full containment of the mapping in the path we are including.
+// Noet that the caller will have to clear and regenerate the path ranks.
 
 void VG::edit_node(int64_t node_id,
                    const vector<tuple<Mapping, bool, bool> >& mappings,
@@ -3694,13 +3714,13 @@ void VG::edit(const map<int64_t, vector<tuple<Mapping, bool, bool> > >& mappings
     remove_null_nodes_forwarding_edges();
 }
 
-void VG::edit_both_directions(const vector<Path>& paths) {
+void VG::edit_both_directions(const vector<Path>& paths_to_add) {
     // Collect the breakpoints
     map<int64_t, set<int64_t>> breakpoints;
     
     std::vector<Path> simplified_paths;
     
-    for(auto path : paths) {
+    for(auto path : paths_to_add) {
         // Simplify the path, just to eliminate adjacent match Edits in the same
         // Mapping (because we don't have or want a breakpoint there)
         simplified_paths.push_back(simplify(path));
@@ -3711,14 +3731,25 @@ void VG::edit_both_directions(const vector<Path>& paths) {
         find_breakpoints(path, breakpoints);
     }
     
+    // Clear existing path ranks.
+    paths.clear_node_ranks();
+    
     // Break any nodes that need to be broken. Save the map we need to translate
-    // from offsets on old nodes to new nodes.
+    // from offsets on old nodes to new nodes. Note that this would mess up the
+    // ranks of nodes in their existing paths, which is why we clear and rebuild
+    // them.
     auto node_translation = ensure_breakpoints(breakpoints);
     
     for(auto path : simplified_paths) {
-        // Now go through each path again, and create new nodes/wire things up.
+        // Now go through each new path again, and create new nodes/wire things up.
         add_nodes_and_edges(path, node_translation);
     }
+    
+    // TODO: add the new path to the graph, with perfect match mappings to all
+    // the new and old stuff it visits.
+    
+    // Rebuild path ranks
+    paths.rebuild_mapping_aux();
     
 }
 

--- a/vg.cpp
+++ b/vg.cpp
@@ -2834,12 +2834,23 @@ void VG::divide_node(Node* node, int pos, Node*& left, Node*& right) {
 #endif
             
             string path_name = paths.mapping_path_name(m);
-            Mapping l, r; divide_invariant_mapping(*m, l, r, pos, left, right);
+            // TODO: this only preserves perfect match paths.
+            // TODO: warn if that precondition is violated
+            Mapping l, r; divide_invariant_mapping(*m, l, r, pos, node, left, right);
             // with the mapping divided, insert the pieces where the old one was
             auto mpit = paths.remove_mapping(m);
-            // insert right then left (insert puts *before* the iterator)
-            mpit = paths.insert_mapping(mpit, path_name, r);
-            mpit = paths.insert_mapping(mpit, path_name, l);
+            if(m->is_reverse()) {
+                // insert left then right in the path, snce we're going through
+                // this node backward (insert puts *before* the iterator)
+                mpit = paths.insert_mapping(mpit, path_name, l);
+                mpit = paths.insert_mapping(mpit, path_name, r);
+            } else {
+                // insert right then left (insert puts *before* the iterator)
+                mpit = paths.insert_mapping(mpit, path_name, r);
+                mpit = paths.insert_mapping(mpit, path_name, l);
+            }
+                
+            
 
 #ifdef debug
 #pragma omp critical (cerr)

--- a/vg.hpp
+++ b/vg.hpp
@@ -419,14 +419,15 @@ public:
     // start (which may include 0 and 1-past-the-end, which should be ignored),
     // break the specified nodes at those positions. Returns a map from old node
     // ID to a map from old node start position to new node pointer in the
-    // graph.
+    // graph. Note that the caller will have to crear and rebuild path rank
+    // data.
     map<int64_t, map<int64_t, Node*>> ensure_breakpoints(const map<int64_t, set<int64_t>>& breakpoints);
     
     // Given a path on nodes that may or may not exist, and a map from node ID
     // in the path's node ID space to a table of offset and actual node, add in
     // all the new sequence and edges required by the path. The given path must
     // not contain adjacent perfect match edits in the same mapping (the removal
-    // of which can be accomplished with the simplify() function).
+    // of which can be accomplished with the simplify() function). 
     void add_nodes_and_edges(const Path& path, const map<int64_t, map<int64_t, Node*>>& node_translation);
     
     // Add in the given node, by value
@@ -595,7 +596,12 @@ public:
 
     // utilities
     // These only work on forward nodes.
+    
+    // Divide a node at a given internal position. Inserts the new nodes in the
+    // correct paths, but can't update the ranks, so they need to be cleared and
+    // re-calculated by the caller.
     void divide_node(Node* node, int pos, Node*& left, Node*& right);
+    // Divide a path at a position. Also invalidates stored rank information.
     void divide_path(map<long, int64_t>& path, long pos, Node*& left, Node*& right);
     //void node_replace_prev(Node* node, Node* before, Node* after);
     //void node_replace_next(Node* node, Node* before, Node* after);


### PR DESCRIPTION
Right now divide_node is messing up any Mappings that happen to be the reverse strand, which is a problem in the BRCA1 graphs in which one of the input sequences was backward relative to the others.

The second commit here fixes that.

The first one goes through and clears and rebuilds the Mapping ranks after a bunch of operations that modify Mappings (and thus invalidate the existing rank values). I unfortunately wasn't able to generate a test case where messed up Mapping ranks actually broke anything; am I doing redundant work here?