### PR TITLE
Add trailing slash to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     apt-get update && \
     apt-get install -y \
         build-essential \
-        pkg-config
+        pkg-config \
         sudo && \
     make get-deps && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The Dockerfile as is won't build because it thinks sudo is a Dockerfile command.