### PR TITLE
Move forward/reverse Step from type to the predicate linking the node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,12 @@ LD_LIB_FLAGS:= -L$(CWD)/$(LIB_DIR) -lvcflib -lgssw -lprotobuf -lhts -lpthread -l
 ifeq ($(shell uname -s),Darwin)
     # We may need libraries from Macports
     # TODO: where does Homebrew keep libraries?
-    LD_LIB_FLAGS += -L/opt/local/lib
-
+    ifeq ($(shell if [ -d /opt/local/lib ];then echo 1;else echo 0;fi), 1)
+       LD_LIB_FLAGS += -L/opt/local/lib
+    endif
+    ifeq ($(shell if [ -d /opt/local/lib ];then echo 1;else echo 0;fi), 1)
+       LD_LIB_FLAGS += -L/usr/local/lib
+    endif
     ROCKSDB_PORTABLE=PORTABLE=1 # needed to build rocksdb without weird assembler options
 else
     # Not on OS X, we can have librt

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -5556,10 +5556,9 @@ void VG::to_turtle(ostream& out, const string& rdf_base_uri) {
 //                string orientation = mapping.position().is_reverse() ? "-" : "+";
 //                s << "P" << "\t" << n->id() << "\t" << p.first << "\t"
 //                  << mapping.rank() << "\t" << orientation << "\t" << cigar << "\n";
-                  s << "s:" << p.first << "#" << mapping.rank() << " <rank> " << mapping.rank() << " ; "  << endl ;
-                  string orientation = mapping.position().is_reverse() ? "<Reverse>" : "<Forward>";
-                  s << "\t a " << orientation <<" ; " << endl;
-                  s << "\t<node> n:" << n->id() << " ; " << endl;
+                  s << "s:" << p.first << "#" << mapping.rank() << "a <Step> ; <rank> " << mapping.rank() << " ; "  << endl ;
+                  string orientation = mapping.position().is_reverse() ? "<reverseOfNode>" : "<node>";
+                  s << "\t" << orientation <<" n:" << n->id() << " ; " << endl;
                   s << "\t<path> p:" << p.first << " . " << endl;
 
 //                s << "n:" << n->id() << " r:value \"" << n->sequence() << "\" . \n"

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -5556,7 +5556,8 @@ void VG::to_turtle(ostream& out, const string& rdf_base_uri) {
 //                string orientation = mapping.position().is_reverse() ? "-" : "+";
 //                s << "P" << "\t" << n->id() << "\t" << p.first << "\t"
 //                  << mapping.rank() << "\t" << orientation << "\t" << cigar << "\n";
-                  s << "s:" << p.first << "#" << mapping.rank() << "a <Step> ; <rank> " << mapping.rank() << " ; "  << endl ;
+                  s << "s:" << p.first << "#" << mapping.rank() << "a <Step> ;" << endl ;
+		  s << " <rank> " << mapping.rank() << " ; "  << endl ;
                   string orientation = mapping.position().is_reverse() ? "<reverseOfNode>" : "<node>";
                   s << "\t" << orientation <<" n:" << n->id() << " ; " << endl;
                   s << "\t<path> p:" << p.first << " . " << endl;


### PR DESCRIPTION
Looking at it this is nicer and I documented this in the wiki. Makes sparql queries easier then adding one more join on the types.