### PR TITLE
Free Node and Edge memory immediately

### DIFF
--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2809,7 +2809,9 @@ void VG::destroy_edge(Edge* edge) {
     }
 
     // drop the last position, erasing the node
-    graph.mutable_edge()->RemoveLast();
+    // manually delete to free memory (RemoveLast does not free)
+    Edge* last_edge = graph.mutable_edge()->ReleaseLast();
+    delete last_edge;
 
     //if (!is_valid()) { cerr << "graph ain't valid" << endl; }
 
@@ -3062,7 +3064,9 @@ void VG::destroy_node(Node* node) {
     // remove this node (which is now the last one) and remove references from the indexes
     node_by_id.erase(node->id());
     node_index.erase(node);
-    graph.mutable_node()->RemoveLast();
+    // manually delete to free memory (RemoveLast does not free)
+    Node* last_node = graph.mutable_node()->ReleaseLast();
+    delete last_node;
     //if (!is_valid()) { cerr << "graph is invalid after destroy_node" << endl; exit(1); }
 }
 


### PR DESCRIPTION
This issue was responsible for large (> 8 GB) memory allocations on the 1mb1kgp test case on Mac OSX when compiled with homebrew and gcc 5.3.