### PR TITLE
Pass Node sequence by constant reference

### DIFF
--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -2911,7 +2911,7 @@ Node* VG::get_node(id_t id) {
     }
 }
 
-Node* VG::create_node(string seq, id_t id) {
+Node* VG::create_node(const string& seq, id_t id) {
     // create the node
     Node* node = graph.add_node();
     node->set_sequence(seq);

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -557,7 +557,7 @@ public:
     bool adjacent(const Position& pos1, const Position& pos2);
 
     // use the VG class to generate ids
-    Node* create_node(string seq, id_t id = 0);
+    Node* create_node(const string& seq, id_t id = 0);
     // find a particular node
     Node* get_node(id_t id);
     // Get the subgraph of a node and all the edges it is responsible for (i.e.


### PR DESCRIPTION
`node->set_sequence(seq)` creates a copy of `seq` anyway, so it shouldn't be necessary to create another copy by passing the sequence into `create_node` by value.