### PR TITLE
resolve reverse complementing bugs with vg sim

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1990,10 +1990,10 @@ int main_sim(int argc, char** argv) {
 
     size_t max_iter = 1000;
     for (int i = 0; i < num_reads; ++i) {
-        auto perfect_read = graph->random_read(read_length, rng, min_id, max_id, true);
+        auto perfect_read = graph->random_read(read_length, rng, min_id, max_id, !forward_only);
         // avoid short reads at the end of the graph by retrying
         int iter = 0;
-        while (perfect_read.first.size() < read_length && ++iter < max_iter) {
+        while (perfect_read.sequence().size() < read_length && ++iter < max_iter) {
             perfect_read = graph->random_read(read_length, rng, min_id, max_id, !forward_only);
             // if we can't make a suitable read in 1000 tries, then maybe the graph is too small?
         }
@@ -2002,12 +2002,12 @@ int main_sim(int argc, char** argv) {
         } else {
             // apply errors
             if (!align_out) {
-                string readseq = introduce_read_errors(perfect_read.first);
+                string readseq = introduce_read_errors(perfect_read.sequence());
                 cout << readseq << endl;
             } else {
                 function<Alignment(uint64_t)> lambda =
                     [&perfect_read] (uint64_t n) {
-                    return perfect_read.second;
+                    return perfect_read;
                 };
                 stream::write(cout, 1, lambda);
             }

--- a/src/vg.cpp
+++ b/src/vg.cpp
@@ -4812,7 +4812,7 @@ void VG::kpaths_of_node(id_t node_id, vector<Path>& paths, int length, int edge_
 }
 
 // todo record as an alignment rather than a string
-pair<string, Alignment> VG::random_read(size_t read_len,
+Alignment VG::random_read(size_t read_len,
                                         mt19937& rng,
                                         id_t min_id,
                                         id_t max_id,
@@ -4870,13 +4870,12 @@ pair<string, Alignment> VG::random_read(size_t read_len,
     uniform_int_distribution<int> binary_dist(0, 1);
     if (either_strand && binary_dist(rng) == 1) {
         // We can flip to the other strand (i.e. node's local reverse orientation).
-        *aln.mutable_path() = reverse_path(aln.path(),
-                                           (function<id_t(id_t)>) ([this](id_t id) {
-                                                   return get_node(id)->sequence().size();
-                                               }));
-        read = reverse_complement(read);
+        reverse_alignment(aln,
+                          (function<id_t(id_t)>) ([this](id_t id) {
+                                  return get_node(id)->sequence().size();
+                              }));
     }
-    return make_pair(read, aln);
+    return aln;
 }
 
 bool VG::is_valid(bool check_nodes,

--- a/src/vg.hpp
+++ b/src/vg.hpp
@@ -949,7 +949,7 @@ public:
     // reads
     // note that even if either_strand is false, having backward nodes in the
     // graph will result in some reads from the global reverse strand.
-    pair<string, Alignment> random_read(size_t read_len, mt19937& rng, id_t min_id, id_t max_id, bool either_strand);
+    Alignment random_read(size_t read_len, mt19937& rng, id_t min_id, id_t max_id, bool either_strand);
 
     // subgraphs
     void disjoint_subgraphs(list<VG>& subgraphs);


### PR DESCRIPTION
`vg sim` was often fond of making reverse complement reads even when it was told not to.